### PR TITLE
Evaluate `expectedElement` at runtime on every access

### DIFF
--- a/Sources/ScreenObject/ScreenObject.swift
+++ b/Sources/ScreenObject/ScreenObject.swift
@@ -10,8 +10,10 @@ open class ScreenObject {
     /// initialization time.
     public let app: XCUIApplication
 
+    private let expectedElementGetter: (XCUIApplication) -> XCUIElement
+
     /// The `XCUIElement` used to evaluate whether the screen is loaded at runtime.
-    public let expectedElement: XCUIElement
+    public var expectedElement: XCUIElement { expectedElementGetter(app) }
 
     /// Whether the screen is loaded at runtime. Evaluated inspecting the `expectedElement`
     /// property.
@@ -25,7 +27,7 @@ open class ScreenObject {
         waitTimeout: TimeInterval = 20
     ) throws {
         self.app = app
-        expectedElement = expectedElementGetter(app)
+        self.expectedElementGetter = expectedElementGetter
         self.waitTimeout = waitTimeout
         try waitForScreen()
     }


### PR DESCRIPTION
This ensures a more accurate representation of whether the element is actually on screen or not when accessed.

By computing it only at `init`-time, we stored a value that might not have been current at the time the tests went to read it.

To test, checkout the branch and run the UI tests. I'll be adding CI to this repo in the next couple of weeks 👍

---

This came out from the work I did in https://github.com/Automattic/simplenote-ios/pull/1401. Without it, the passcode screen was never found because there was a delay between when the `ScreenObject` was created and when the actual screen was presented. The `ScreenObject` stored a copy of the expected element that was not visible, even though the app had updated to make that element visible.