### PR TITLE
Configure CI via Buildkite

### DIFF
--- a/.buildkite/commands/run-tests.sh
+++ b/.buildkite/commands/run-tests.sh
@@ -1,5 +1,18 @@
 #!/bin/bash -eu
 
+# Notice that:
+#
+# - We are using raw `xcodebuild` without extra tooling such as Fastlane,
+#   `xcpretty`, or `xcbeautify`. This is an intentional compromise to keep the
+#   setup lean, as adding any of those would require extras in CI such as
+#   chating for what, right now, looks like merely a log readability gain.
+#
+# - The iOS Simulator version is hardcoded in the command call, unlike the
+#   Simulator device, so we have a single source of truth. The downside is that
+#   the syntax in the pipeline is less clear: a reader might as where's the
+#   iOS version set. As long as we only need to test against the latest iOS
+#   version, that seems like a reasonable tradeoff to make it easier to move to
+#   newer versions as they are released.
 SIMULATOR_NAME=$1
 
 xcodebuild clean test \

--- a/.buildkite/commands/run-tests.sh
+++ b/.buildkite/commands/run-tests.sh
@@ -1,0 +1,8 @@
+#!/bin/bash -eu
+
+SIMULATOR_NAME=$1
+
+xcodebuild clean test \
+  -project 'ScreenObject.xcodeproj' \
+  -scheme 'ScreenObject' \
+  -destination "platform=iOS Simulator,name=$SIMULATOR_NAME,OS=14.5"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -5,21 +5,13 @@ common_params:
 
 steps:
   - label: "🧪 Build and Test (iPhone 12 Simulator)"
-    command: |
-      xcodebuild clean test \
-        -project 'ScreenObject.xcodeproj' \
-        -scheme 'ScreenObject' \
-        -destination 'platform=iOS Simulator,name=iPhone 12,OS=14.5'
+    command: .buildkite/commands/run-tests.sh 'iPhone 12'
     env: *common_env
     agents:
       queue: 'mac'
 
   - label: "🧪 Build and Test (iPad Pro (12.9-inch) (5th generation) Simulator)"
-    command: |
-      xcodebuild clean test \
-        -project 'ScreenObject.xcodeproj' \
-        -scheme 'ScreenObject' \
-        -destination 'platform=iOS Simulator,name=iPad Pro (12.9-inch) (5th generation),OS=14.5'
+    command: .buildkite/commands/run-tests.sh 'iPad Pro (12.9-inch) (5th generation)'
     env: *common_env
     agents:
       queue: 'mac'

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -13,3 +13,13 @@ steps:
     env: *common_env
     agents:
       queue: 'mac'
+
+  - label: "🧪 Build and Test (iPad Pro (12.9-inch) (5th generation) Simulator)"
+    command: |
+      xcodebuild clean test \
+        -project 'ScreenObject.xcodeproj' \
+        -scheme 'ScreenObject' \
+        -destination 'platform=iOS Simulator,name=iPad Pro (12.9-inch) (5th generation),OS=14.5'
+    env: *common_env
+    agents:
+      queue: 'mac'

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,0 +1,15 @@
+# Nodes with values to reuse in the pipeline.
+common_params:
+  env: &common_env
+    IMAGE_ID: xcode-12.5.1
+
+steps:
+  - label: "🧪 Build and Test (iPhone 12 Simulator)"
+    command: |
+      xcodebuild clean test \
+        -project 'ScreenObject.xcodeproj' \
+        -scheme 'ScreenObject' \
+        -destination 'platform=iOS Simulator,name=iPhone 12,OS=14.5'
+    env: *common_env
+    agents:
+      queue: 'mac'

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,17 +1,11 @@
-# Nodes with values to reuse in the pipeline.
-common_params:
-  env: &common_env
-    IMAGE_ID: xcode-12.5.1
+env:
+  IMAGE_ID: xcode-12.5.1
+agents:
+  queue: 'mac'
 
 steps:
   - label: "🧪 Build and Test (iPhone 12 Simulator)"
     command: .buildkite/commands/run-tests.sh 'iPhone 12'
-    env: *common_env
-    agents:
-      queue: 'mac'
 
   - label: "🧪 Build and Test (iPad Pro (12.9-inch) (5th generation) Simulator)"
     command: .buildkite/commands/run-tests.sh 'iPad Pro (12.9-inch) (5th generation)'
-    env: *common_env
-    agents:
-      queue: 'mac'

--- a/ScreenObject.xcodeproj/xcshareddata/xcschemes/ScreenObject.xcscheme
+++ b/ScreenObject.xcodeproj/xcshareddata/xcschemes/ScreenObject.xcscheme
@@ -28,6 +28,16 @@
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "3FF14351266E2C7500138163"
+               BuildableName = "TestAppUITests.xctest"
+               BlueprintName = "TestAppUITests"
+               ReferencedContainer = "container:ScreenObject.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
    </TestAction>
    <LaunchAction


### PR DESCRIPTION
Integrates Buildkite to run the UI tests against iPhone 12 and latest iPad Pro.
We may add more Simulator targets in the future, e.g. if we discover fiddly methods that behave differently across Simulator.

To test, verify that CI run and passed.