### PR TITLE
Test PR to show how Buildkite resolves environment variables

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,11 +1,15 @@
 env:
-  IMAGE_ID: xcode-12.5.1
+  GLOBAL: global value we don't try to override
+  GLOBAL_OVERRIDE: if you read this, then the global value takes precendence
 agents:
-  queue: 'mac'
+  queue: 'upload'
 
 steps:
-  - label: "🧪 Build and Test (iPhone 12 Simulator)"
-    command: .buildkite/commands/run-tests.sh 'iPhone 12'
-
-  - label: "🧪 Build and Test (iPad Pro (12.9-inch) (5th generation) Simulator)"
-    command: .buildkite/commands/run-tests.sh 'iPad Pro (12.9-inch) (5th generation)'
+  - label: "Test for env variables resolution"
+    command: |
+      echo "GLOBAL = $$GLOBAL"
+      echo "GLOBAL_OVERRIDE = $$GLOBAL_OVERRIDE"
+      echo "LOCAL = $$LOCAL"
+    env:
+      LOCAL: local value
+      GLOBAL_OVERRIDE: if you read this, then the global value was overridden by the local one


### PR DESCRIPTION
See discussion at https://github.com/Automattic/ScreenObject/pull/6/files#r695599750.

[This](https://github.com/Automattic/ScreenObject/blob/ecbe2598150c59731718c96b275efce5f7e17c47/.buildkite/pipeline.yml) pipeline:

```yml
env:
  GLOBAL: global value we don't try to override
  GLOBAL_OVERRIDE: if you read this, then the global value takes precedence
agents:
  queue: 'upload'

steps:
  - label: "Test for env variables resolution"
    command: |
      echo "GLOBAL = $$GLOBAL"
      echo "GLOBAL_OVERRIDE = $$GLOBAL_OVERRIDE"
      echo "LOCAL = $$LOCAL"
    env:
      LOCAL: local value
      GLOBAL_OVERRIDE: if you read this, then the global value was overridden by the local one
```

produces [this](https://buildkite.com/wordpress-mobile/screenobject/builds/12#d92da518-fe14-4ae3-8f71-864fa792afc0/81) output:

```
[2021-08-26T03:06:04Z] GLOBAL = global value we don't try to override
[2021-08-26T03:06:04Z] GLOBAL_OVERRIDE = if you read this, then the global value was overridden by the local one
[2021-08-26T03:06:04Z] LOCAL = local value
```

Meaning: the `env` value defined in the `step` overrides the `env` value defined in the pipeline root.