### PR TITLE
Don't explicitly fail the tests during `init` if the screen is not loaded

### DIFF
--- a/Sources/ScreenObject/ScreenObject.swift
+++ b/Sources/ScreenObject/ScreenObject.swift
@@ -35,15 +35,19 @@ open class ScreenObject {
     @discardableResult
     func waitForScreen() throws -> Self {
         XCTContext.runActivity(named: "Confirm screen \(self) is loaded") { (activity) in
-            let result = waitFor(element: expectedElement, predicate: "isEnabled == true", timeout: 20)
+            let result = waitFor(
+                element: expectedElement,
+                predicate: "isEnabled == true",
+                timeout: self.waitTimeout
+            )
             XCTAssert(result, "Screen \(self) is not loaded.")
         }
         return self
     }
 
-    private func waitFor(element: XCUIElement, predicate: String, timeout: Int = 5) -> Bool {
+    private func waitFor(element: XCUIElement, predicate: String, timeout: TimeInterval = 5) -> Bool {
         let elementPredicate = XCTNSPredicateExpectation(predicate: NSPredicate(format: predicate), object: element)
-        let result = XCTWaiter.wait(for: [elementPredicate], timeout: TimeInterval(timeout))
+        let result = XCTWaiter.wait(for: [elementPredicate], timeout: timeout)
 
         return result == .completed
     }

--- a/Sources/ScreenObject/ScreenObject.swift
+++ b/Sources/ScreenObject/ScreenObject.swift
@@ -6,6 +6,10 @@ import XCTest
 // and those are obviously specific to each screen, hence should be added by each subclass.
 open class ScreenObject {
 
+    public enum WaitForScreenError: Equatable, Error {
+        case timedOut
+    }
+
     /// The `XCUIApplication` instance this screen is part of. This is the value passed at
     /// initialization time.
     public let app: XCUIApplication
@@ -34,13 +38,14 @@ open class ScreenObject {
 
     @discardableResult
     func waitForScreen() throws -> Self {
-        XCTContext.runActivity(named: "Confirm screen \(self) is loaded") { (activity) in
+        try XCTContext.runActivity(named: "Confirm screen \(self) is loaded") { (activity) in
             let result = waitFor(
                 element: expectedElement,
                 predicate: "isEnabled == true",
                 timeout: self.waitTimeout
             )
-            XCTAssert(result, "Screen \(self) is not loaded.")
+
+            guard result else { throw WaitForScreenError.timedOut }
         }
         return self
     }

--- a/Sources/ScreenObject/ScreenObject.swift
+++ b/Sources/ScreenObject/ScreenObject.swift
@@ -45,15 +45,24 @@ open class ScreenObject {
                 timeout: self.waitTimeout
             )
 
-            guard result else { throw WaitForScreenError.timedOut }
+            guard result == .completed else { throw WaitForScreenError.timedOut }
         }
         return self
     }
 
-    private func waitFor(element: XCUIElement, predicate: String, timeout: TimeInterval) -> Bool {
-        let elementPredicate = XCTNSPredicateExpectation(predicate: NSPredicate(format: predicate), object: element)
-        let result = XCTWaiter.wait(for: [elementPredicate], timeout: timeout)
-
-        return result == .completed
+    private func waitFor(
+        element: XCUIElement,
+        predicate: String,
+        timeout: TimeInterval
+    ) -> XCTWaiter.Result {
+        XCTWaiter.wait(
+            for: [
+                XCTNSPredicateExpectation(
+                    predicate: NSPredicate(format: predicate),
+                    object: element
+                )
+            ],
+            timeout: timeout
+        )
     }
 }

--- a/Sources/ScreenObject/ScreenObject.swift
+++ b/Sources/ScreenObject/ScreenObject.swift
@@ -50,7 +50,7 @@ open class ScreenObject {
         return self
     }
 
-    private func waitFor(element: XCUIElement, predicate: String, timeout: TimeInterval = 5) -> Bool {
+    private func waitFor(element: XCUIElement, predicate: String, timeout: TimeInterval) -> Bool {
         let elementPredicate = XCTNSPredicateExpectation(predicate: NSPredicate(format: predicate), object: element)
         let result = XCTWaiter.wait(for: [elementPredicate], timeout: timeout)
 

--- a/Tests/TestAppUITests/TestAppUITests.swift
+++ b/Tests/TestAppUITests/TestAppUITests.swift
@@ -3,14 +3,14 @@ import XCTest
 
 class TestAppUITests: XCTestCase {
 
+    let app = XCUIApplication()
+
     override func setUpWithError() throws {
+        app.launch()
         continueAfterFailure = false
     }
 
-    func testExample() throws {
-        let app = XCUIApplication()
-        app.launch()
-
+    func testIsLoadedReturnsTrueWhenScreenIsLoaded() throws {
         let screen = try HelloWorldScreen()
         XCTAssertTrue(screen.isLoaded)
     }

--- a/Tests/TestAppUITests/TestAppUITests.swift
+++ b/Tests/TestAppUITests/TestAppUITests.swift
@@ -15,9 +15,13 @@ class TestAppUITests: XCTestCase {
         XCTAssertTrue(screen.isLoaded)
     }
 
-    func testScreenInitFailsWhenScreenIsNotLoaded() throws {
-        XCTExpectFailure("Attempting to init a screen that is not loaded currently fails the tests")
-        _ = try MissingScreen(app: app)
+    func testScreenInitThrowsWhenScreenIsNotLoaded() throws {
+        do {
+            _ = try MissingScreen(app: app)
+            XCTFail("Expected `ScreenObject` `init` to throw, but it didn't")
+        } catch {
+            XCTAssertEqual(error as? ScreenObject.WaitForScreenError, .timedOut)
+        }
     }
 }
 

--- a/Tests/TestAppUITests/TestAppUITests.swift
+++ b/Tests/TestAppUITests/TestAppUITests.swift
@@ -14,11 +14,28 @@ class TestAppUITests: XCTestCase {
         let screen = try HelloWorldScreen()
         XCTAssertTrue(screen.isLoaded)
     }
+
+    func testScreenInitFailsWhenScreenIsNotLoaded() throws {
+        XCTExpectFailure("Attempting to init a screen that is not loaded currently fails the tests")
+        _ = try MissingScreen(app: app)
+    }
 }
 
 final class HelloWorldScreen: ScreenObject {
 
     init(app: XCUIApplication = XCUIApplication()) throws {
         try super.init(expectedElementGetter: { $0.staticTexts["Hello, world!"] })
+    }
+}
+
+/// A screen that doesn't exist. Use it to test the init failure behavior.
+class MissingScreen: ScreenObject {
+
+    init(app: XCUIApplication) throws {
+        try super.init(
+            expectedElementGetter: { $0.staticTexts["this screen does not exist"] },
+            app: app,
+            waitTimeout: 1
+        )
     }
 }


### PR DESCRIPTION
Because this logic now lives in a library, we cannot ruthlessly fail the tests anymore and need instead of be more flexible, delegating to the consumer the responsibility to decide whether a test should fail because the `ScreenObject` instance is not yet loaded.

---

I based this against `add/buildkite` because I wanted CI to run on it, but it should be merged only after #6  that one goes into `trunk`:

- [x] Wait for #6 to be merged