### PR TITLE
Add support for subclasses specifying multiple expected elements

### DIFF
--- a/Sources/ScreenObject/ScreenObject.swift
+++ b/Sources/ScreenObject/ScreenObject.swift
@@ -14,10 +14,15 @@ open class ScreenObject {
     /// initialization time.
     public let app: XCUIApplication
 
-    private let expectedElementGetter: (XCUIApplication) -> XCUIElement
+    private let expectedElementGetters: [(XCUIApplication) -> XCUIElement]
 
     /// The `XCUIElement` used to evaluate whether the screen is loaded at runtime.
-    public var expectedElement: XCUIElement { expectedElementGetter(app) }
+    public var expectedElement: XCUIElement {
+        guard let getter = expectedElementGetters.first else {
+            preconditionFailure("`expectedElementGetters` array was empty. This should never occur!")
+        }
+        return getter(app)
+    }
 
     /// Whether the screen is loaded at runtime. Evaluated inspecting the `expectedElement`
     /// property.
@@ -31,7 +36,7 @@ open class ScreenObject {
         waitTimeout: TimeInterval = 20
     ) throws {
         self.app = app
-        self.expectedElementGetter = expectedElementGetter
+        self.expectedElementGetters = [expectedElementGetter]
         self.waitTimeout = waitTimeout
         try waitForScreen()
     }

--- a/Sources/ScreenObject/ScreenObject.swift
+++ b/Sources/ScreenObject/ScreenObject.swift
@@ -44,13 +44,15 @@ open class ScreenObject {
     @discardableResult
     func waitForScreen() throws -> Self {
         try XCTContext.runActivity(named: "Confirm screen \(self) is loaded") { (activity) in
-            let result = waitFor(
-                element: expectedElement,
-                predicate: "isEnabled == true",
-                timeout: self.waitTimeout
-            )
+            try expectedElementGetters.forEach { getter in
+                let result = waitFor(
+                    element: getter(app),
+                    predicate: "isEnabled == true",
+                    timeout: self.waitTimeout
+                )
 
-            guard result == .completed else { throw WaitForScreenError.timedOut }
+                guard result == .completed else { throw WaitForScreenError.timedOut }
+            }
         }
         return self
     }

--- a/Tests/TestApp/ContentView.swift
+++ b/Tests/TestApp/ContentView.swift
@@ -2,8 +2,11 @@ import SwiftUI
 
 struct ContentView: View {
     var body: some View {
-        Text("Hello, world!")
-            .padding()
+        VStack {
+            Text("Hello, world!")
+                .padding()
+            Text("Subtitle")
+        }
     }
 }
 

--- a/Tests/TestAppUITests/TestAppUITests.swift
+++ b/Tests/TestAppUITests/TestAppUITests.swift
@@ -15,12 +15,35 @@ class TestAppUITests: XCTestCase {
         XCTAssertTrue(screen.isLoaded)
     }
 
+    func testIsLoadedReturnsTrueWhenScreenWithMultipleElementsIsLoaded() throws {
+        let screen = try MultipleElementsScreen(app: app)
+        XCTAssertTrue(screen.isLoaded)
+    }
+
     func testScreenInitThrowsWhenScreenIsNotLoaded() throws {
         do {
             _ = try MissingScreen(app: app)
             XCTFail("Expected `ScreenObject` `init` to throw, but it didn't")
         } catch {
             XCTAssertEqual(error as? ScreenObject.WaitForScreenError, .timedOut)
+        }
+    }
+
+    func testScreenInitThrowsWhenScreenWithMultipleElementsIsNotLoaded() throws {
+        do {
+            _ = try MissingMultipleElementsScreen(app: app)
+            XCTFail("Expected `ScreenObject` `init` to throw, but it didn't")
+        } catch {
+            XCTAssertEqual(error as? ScreenObject.WaitForScreenError, .timedOut)
+        }
+    }
+
+    func testInitThrowsWhenGivenEmptyGettersArray() throws {
+        do {
+            _ = try ScreenObject(expectedElementGetters: [], app: app)
+            XCTFail("Expected `ScreenObject` `init` to throw, but it didn't")
+        } catch {
+            XCTAssertEqual(error as? ScreenObject.InitError, .emptyExpectedElementGettersArray)
         }
     }
 }
@@ -32,6 +55,23 @@ final class HelloWorldScreen: ScreenObject {
     }
 }
 
+/// A screen that requires multiple elements to be considered loaded.
+///
+/// Currently, this is the same screen as `HelloWorldScreen` in the app, but we might refine in the
+/// future as we add more functionality.
+class MultipleElementsScreen: ScreenObject {
+
+    init(app: XCUIApplication) throws {
+        try super.init(
+            expectedElementGetters: [
+                { $0.staticTexts["Hello, world!"] },
+                { $0.staticTexts["Subtitle"] }
+            ],
+            app: app
+        )
+    }
+}
+
 /// A screen that doesn't exist. Use it to test the init failure behavior.
 class MissingScreen: ScreenObject {
 
@@ -40,6 +80,22 @@ class MissingScreen: ScreenObject {
             expectedElementGetter: { $0.staticTexts["this screen does not exist"] },
             app: app,
             waitTimeout: 1
+        )
+    }
+}
+
+/// A screen that doesn't exist with multiple required elements. Use it to test the init failure
+/// behavior.
+class MissingMultipleElementsScreen: ScreenObject {
+
+    init(app: XCUIApplication) throws {
+        try super.init(
+            expectedElementGetters: [
+                { $0.staticTexts["Hello, world!"] },
+                { $0.staticTexts["this screen does not exist"] }
+            ],
+            app: app,
+            waitTimeout: 1 // We know the screen is not there, let's not wait for it for long
         )
     }
 }

--- a/Tests/TestAppUITests/TestAppUITests.swift
+++ b/Tests/TestAppUITests/TestAppUITests.swift
@@ -11,7 +11,7 @@ class TestAppUITests: XCTestCase {
     }
 
     func testIsLoadedReturnsTrueWhenScreenIsLoaded() throws {
-        let screen = try HelloWorldScreen()
+        let screen = try HelloWorldScreen(app: app)
         XCTAssertTrue(screen.isLoaded)
     }
 
@@ -48,10 +48,10 @@ class TestAppUITests: XCTestCase {
     }
 }
 
-final class HelloWorldScreen: ScreenObject {
+class HelloWorldScreen: ScreenObject {
 
-    init(app: XCUIApplication = XCUIApplication()) throws {
-        try super.init(expectedElementGetter: { $0.staticTexts["Hello, world!"] })
+    init(app: XCUIApplication) throws {
+        try super.init(expectedElementGetter: { $0.staticTexts["Hello, world!"] }, app: app)
     }
 }
 
@@ -79,7 +79,7 @@ class MissingScreen: ScreenObject {
         try super.init(
             expectedElementGetter: { $0.staticTexts["this screen does not exist"] },
             app: app,
-            waitTimeout: 1
+            waitTimeout: 1 // We know the screen is not there, let's not wait for it for long
         )
     }
 }


### PR DESCRIPTION
Add a new init method that takes more than one element getter closure. This way, we'll be able to create `ScreenObject` subclasses that have more thorough checks on the elements that determine whether the screen they represent is loaded.

Beyond the new tests, you can look at https://github.com/Automattic/simplenote-ios/pull/1430 for a real-world example.