### PR TITLE
[UITII] Swap the elements search logic in `init` and `isLoaded`

### DIFF
--- a/Sources/ScreenObject/ScreenObject.swift
+++ b/Sources/ScreenObject/ScreenObject.swift
@@ -32,19 +32,15 @@ open class ScreenObject {
         return getter(app)
     }
 
-    @discardableResult
-    public func isLoaded() throws -> Bool {
-        try XCTContext.runActivity(named: "Confirm screen \(self) is loaded") { (activity) in
-            try expectedElementGetters.forEach { getter in
-                let result = waitFor(
-                    element: getter(app),
-                    predicate: "isEnabled == true",
-                    timeout: self.waitTimeout
-                )
-
-                guard result == .completed else { throw WaitForScreenError.timedOut }
-            }
+    public var isLoaded: Bool {
+        do {
+            try waitForScreen()
+        } catch {
+            print(error)
         }
+
+        // If the execution gets here, it means all elements were found,
+        // hence the hardcoded return value
         return true
     }
 

--- a/Sources/ScreenObject/ScreenObject.swift
+++ b/Sources/ScreenObject/ScreenObject.swift
@@ -32,6 +32,7 @@ open class ScreenObject {
         return getter(app)
     }
 
+    /// Whether the whole screen is loaded at runtime (all elements in `expectedElementGetters`).
     public var isLoaded: Bool {
         do {
             try waitForScreen()
@@ -40,7 +41,7 @@ open class ScreenObject {
             return false
         }
 
-        // If the execution gets here, it means all elements were found,
+        // The execution gets here only if all elements were found,
         // hence the hardcoded return value
         return true
     }

--- a/Sources/ScreenObject/ScreenObject.swift
+++ b/Sources/ScreenObject/ScreenObject.swift
@@ -76,11 +76,22 @@ open class ScreenObject {
         try waitForScreen(firstElementOnly: true)
     }
 
+    /// Waits for the first element from expectedElementGetters to load (if `firstElementOnly` is `true`)
+    /// or, by default, for all elements to load (`firstElementOnly` is `false`).
     @discardableResult
     public func waitForScreen(firstElementOnly: Bool = false) throws -> Self {
-        let testedGetters = firstElementOnly ? [expectedElementGetters.first!] : expectedElementGetters
+        var testedGetters: Array<(XCUIApplication) -> XCUIElement>,
+            activityDescription: String
 
-        try XCTContext.runActivity(named: "Confirm screen \(self) is loaded") { (activity) in
+        if firstElementOnly {
+            testedGetters = [expectedElementGetters.first!]
+            activityDescription = "Confirm first element from `expectedElementGetters` is loaded on screen \(self)"
+        } else {
+            testedGetters = expectedElementGetters
+            activityDescription = "Confirm whole screen \(self) is loaded"
+        }
+
+        try XCTContext.runActivity(named: activityDescription) { (activity) in
             try testedGetters.forEach { getter in
                 let result = waitFor(
                     element: getter(app),

--- a/Sources/ScreenObject/ScreenObject.swift
+++ b/Sources/ScreenObject/ScreenObject.swift
@@ -7,7 +7,7 @@ import XCTest
 open class ScreenObject {
 
     /// The default time used when waiting.
-    public static let defaultWaitTimeout: TimeInterval = 10
+    public static let defaultWaitTimeout: TimeInterval = 20
 
     public enum WaitForScreenError: Equatable, Error {
         case timedOut

--- a/Sources/ScreenObject/ScreenObject.swift
+++ b/Sources/ScreenObject/ScreenObject.swift
@@ -80,14 +80,16 @@ open class ScreenObject {
     /// or, by default, for all elements to load (`firstElementOnly` is `false`).
     @discardableResult
     public func waitForScreen(firstElementOnly: Bool = false) throws -> Self {
-        var gettersToTest: Array<(XCUIApplication) -> XCUIElement>,
+        guard let firstGetter = expectedElementGetters.first else {
+            throw InitError.emptyExpectedElementGettersArray
+        }
+
+        let gettersToTest = firstElementOnly ? [firstGetter] : expectedElementGetters,
             activityDescription: String
 
         if firstElementOnly {
-            gettersToTest = [expectedElementGetters.first!]
             activityDescription = "Confirm first element from `expectedElementGetters` is loaded on screen \(self)"
         } else {
-            gettersToTest = expectedElementGetters
             activityDescription = "Confirm whole screen \(self) is loaded"
         }
 

--- a/Sources/ScreenObject/ScreenObject.swift
+++ b/Sources/ScreenObject/ScreenObject.swift
@@ -37,6 +37,7 @@ open class ScreenObject {
             try waitForScreen()
         } catch {
             print(error)
+            return false
         }
 
         // If the execution gets here, it means all elements were found,

--- a/Sources/ScreenObject/ScreenObject.swift
+++ b/Sources/ScreenObject/ScreenObject.swift
@@ -24,6 +24,14 @@ open class ScreenObject {
 
     private let expectedElementGetters: [(XCUIApplication) -> XCUIElement]
 
+    /// The `XCUIElement` used to evaluate whether the screen is loaded at runtime.
+    public var expectedElement: XCUIElement {
+        guard let getter = expectedElementGetters.first else {
+            preconditionFailure("`expectedElementGetters` array was empty. This should never occur!")
+        }
+        return getter(app)
+    }
+
     /// Whether the whole screen is loaded at runtime (all elements in `expectedElementGetters`).
     public var isLoaded: Bool {
         do {

--- a/Sources/ScreenObject/ScreenObject.swift
+++ b/Sources/ScreenObject/ScreenObject.swift
@@ -37,7 +37,6 @@ open class ScreenObject {
         do {
             try waitForScreen()
         } catch {
-            print(error)
             return false
         }
 

--- a/Sources/ScreenObject/ScreenObject.swift
+++ b/Sources/ScreenObject/ScreenObject.swift
@@ -80,19 +80,19 @@ open class ScreenObject {
     /// or, by default, for all elements to load (`firstElementOnly` is `false`).
     @discardableResult
     public func waitForScreen(firstElementOnly: Bool = false) throws -> Self {
-        var testedGetters: Array<(XCUIApplication) -> XCUIElement>,
+        var gettersToTest: Array<(XCUIApplication) -> XCUIElement>,
             activityDescription: String
 
         if firstElementOnly {
-            testedGetters = [expectedElementGetters.first!]
+            gettersToTest = [expectedElementGetters.first!]
             activityDescription = "Confirm first element from `expectedElementGetters` is loaded on screen \(self)"
         } else {
-            testedGetters = expectedElementGetters
+            gettersToTest = expectedElementGetters
             activityDescription = "Confirm whole screen \(self) is loaded"
         }
 
         try XCTContext.runActivity(named: activityDescription) { (activity) in
-            try testedGetters.forEach { getter in
+            try gettersToTest.forEach { getter in
                 let result = waitFor(
                     element: getter(app),
                     predicate: "isEnabled == true",

--- a/Tests/TestAppUITests/TestAppUITests.swift
+++ b/Tests/TestAppUITests/TestAppUITests.swift
@@ -20,6 +20,11 @@ class TestAppUITests: XCTestCase {
         XCTAssertTrue(screen.isLoaded)
     }
 
+    func testIsLoadedReturnsFalseWhenScreenWithMultipleElementsNotLoaded() throws {
+        let screen = try MissingSecondElementScreen(app: app)
+        XCTAssertFalse(screen.isLoaded)
+    }
+
     func testScreenInitThrowsWhenScreenIsNotLoaded() throws {
         do {
             _ = try MissingScreen(app: app)
@@ -31,7 +36,7 @@ class TestAppUITests: XCTestCase {
 
     func testScreenInitThrowsWhenScreenWithMultipleElementsIsNotLoaded() throws {
         do {
-            _ = try MissingMultipleElementsScreen(app: app)
+            _ = try MissingFirstElementScreen(app: app)
             XCTFail("Expected `ScreenObject` `init` to throw, but it didn't")
         } catch {
             XCTAssertEqual(error as? ScreenObject.WaitForScreenError, .timedOut)
@@ -84,9 +89,9 @@ class MissingScreen: ScreenObject {
     }
 }
 
-/// A screen that doesn't exist with multiple required elements. Use it to test the init failure
+/// A screen where the first element does not exist. Use it to test the init failure
 /// behavior.
-class MissingMultipleElementsScreen: ScreenObject {
+class MissingFirstElementScreen: ScreenObject {
 
     init(app: XCUIApplication) throws {
         try super.init(
@@ -94,8 +99,22 @@ class MissingMultipleElementsScreen: ScreenObject {
                 { $0.staticTexts["this screen does not exist"] },
                 { $0.staticTexts["Hello, world!"] }
             ],
-            app: app,
-            waitTimeout: 1 // We know the screen is not there, let's not wait for it for long
+            app: app
+        )
+    }
+}
+
+/// A screen where the first element exists, but the second does not. Use it to test the init passing,
+/// and `isLoaded` failure behavior.
+class MissingSecondElementScreen: ScreenObject {
+
+    init(app: XCUIApplication) throws {
+        try super.init(
+            expectedElementGetters: [
+                { $0.staticTexts["Hello, world!"] },
+                { $0.staticTexts["this screen does not exist"] }
+            ],
+            app: app
         )
     }
 }

--- a/Tests/TestAppUITests/TestAppUITests.swift
+++ b/Tests/TestAppUITests/TestAppUITests.swift
@@ -31,7 +31,7 @@ class TestAppUITests: XCTestCase {
 
     func testScreenInitThrowsWhenScreenWithMultipleElementsIsNotLoaded() throws {
         do {
-            _ = try MissingMultipleElementsScreen(app: app).isFullyLoaded()
+            _ = try MissingMultipleElementsScreen(app: app)
             XCTFail("Expected `ScreenObject` `init` to throw, but it didn't")
         } catch {
             XCTAssertEqual(error as? ScreenObject.WaitForScreenError, .timedOut)
@@ -91,8 +91,8 @@ class MissingMultipleElementsScreen: ScreenObject {
     init(app: XCUIApplication) throws {
         try super.init(
             expectedElementGetters: [
-                { $0.staticTexts["Hello, world!"] },
-                { $0.staticTexts["this screen does not exist"] }
+                { $0.staticTexts["this screen does not exist"] },
+                { $0.staticTexts["Hello, world!"] }
             ],
             app: app,
             waitTimeout: 1 // We know the screen is not there, let's not wait for it for long

--- a/Tests/TestAppUITests/TestAppUITests.swift
+++ b/Tests/TestAppUITests/TestAppUITests.swift
@@ -31,7 +31,7 @@ class TestAppUITests: XCTestCase {
 
     func testScreenInitThrowsWhenScreenWithMultipleElementsIsNotLoaded() throws {
         do {
-            _ = try MissingMultipleElementsScreen(app: app)
+            _ = try MissingMultipleElementsScreen(app: app).isFullyLoaded()
             XCTFail("Expected `ScreenObject` `init` to throw, but it didn't")
         } catch {
             XCTAssertEqual(error as? ScreenObject.WaitForScreenError, .timedOut)


### PR DESCRIPTION
This changes the "ideology" of the `ScreenObject` a bit, so I'm interested in your feedback / opinions about if it makes sense to lose a bit of implicit test coverage in favour of time savings.

### Reason

Every time the screen is instantiated, `ScreenObject` will check if all elements from `expectedElementGetters` are present on screen (to be more precise, enabled). This is good for testing density, but not as good for saving time. Currently, the process of navigating the app is an implicit test by itself, since Xcode will check for all screen elements' presence every time it uses a new screen. `ScreenObject` also has the `isLoaded` property, which will check if the first element from `expectedElementGetters` exists.

### Changes

This PR swaps the logic of elements presence check in `init` and `isLoaded`:

- Now, during screen instantiation, only the first element from `expectedElementGetters` will be checked for presence.
- If we need to check for the presence of the whole `expectedElementGetters`, we can use `isLoaded`.

This way, we will still use the "smart" wait provided by `waitFor` method for the first element in `expectedElementGetters`, and we can use `isLoaded` at times when we need to check for the whole screen load. 

### Impact

We might need to reconsider what element will be the first one in the numerous screens we use in WP and WC, but so far the tests are passing with no changes in this area.

Since several tests in WCiOS (see the last paragraph [here](https://github.com/woocommerce/woocommerce-ios/pull/7118)) use no explicit asserts, and rely on the `init`, I will add the explicit asserts to these two tests if the current PR lands. cc @thehenrybyrd 

### Time savings

This change makes WPiOS tests 7.6 minutes faster (30.4 ~> 22.8 min locally / ~40 min ~> ~33 min on CI), and for WCiOS the change is 1.2 minutes (4 min ~> 2.8 min locally / ~11 min ~> ~9 min on CI).

### Testing

Testing PR for WPiOS: wordpress-mobile/WordPress-iOS/pull/18912
Testing PR for WCiOS: woocommerce/woocommerce-ios/pull/7118

Additionally, you might want to run the tests available in `ScreenObject` package.