### PR TITLE
Replace the use of isEnabled() to isHittable()

### DIFF
--- a/Sources/ScreenObject/ScreenObject.swift
+++ b/Sources/ScreenObject/ScreenObject.swift
@@ -10,7 +10,7 @@ open class ScreenObject {
     public static let defaultWaitTimeout: TimeInterval = 20
 
     public enum WaitForScreenError: Equatable, Error {
-        case timedOut
+        case timedOut = "Timed out"
     }
 
     /// The possible errors the initialization process can throw.
@@ -101,11 +101,7 @@ open class ScreenObject {
                     timeout: self.waitTimeout
                 )
 
-                // guard result == .completed else { throw WaitForScreenError.timedOut }
-                guard result == .completed else { 
-                    console.Error("Element not hittable!")
-                    return false 
-                }
+                guard result == .completed else { throw WaitForScreenError.timedOut }
             }
         }
         return self

--- a/Sources/ScreenObject/ScreenObject.swift
+++ b/Sources/ScreenObject/ScreenObject.swift
@@ -97,7 +97,7 @@ open class ScreenObject {
             try gettersToTest.forEach { getter in
                 let result = waitFor(
                     element: getter(app),
-                    predicate: "isEnabled == true",
+                    predicate: "isEnabled == true && isHittable == true",
                     timeout: self.waitTimeout
                 )
 

--- a/Sources/ScreenObject/ScreenObject.swift
+++ b/Sources/ScreenObject/ScreenObject.swift
@@ -10,7 +10,7 @@ open class ScreenObject {
     public static let defaultWaitTimeout: TimeInterval = 20
 
     public enum WaitForScreenError: Equatable, Error {
-        case timedOut = "Timed out"
+        case timedOut
     }
 
     /// The possible errors the initialization process can throw.

--- a/Sources/ScreenObject/ScreenObject.swift
+++ b/Sources/ScreenObject/ScreenObject.swift
@@ -97,11 +97,15 @@ open class ScreenObject {
             try gettersToTest.forEach { getter in
                 let result = waitFor(
                     element: getter(app),
-                    predicate: "isEnabled == true && isHittable == true",
+                    predicate: "isHittable == true",
                     timeout: self.waitTimeout
                 )
 
-                guard result == .completed else { throw WaitForScreenError.timedOut }
+                // guard result == .completed else { throw WaitForScreenError.timedOut }
+                guard result == .completed else { 
+                    console.Error("Element not hittable!")
+                    return false 
+                }
             }
         }
         return self


### PR DESCRIPTION
### What does this do?
To replace the use of `isEnabled()` with `isHittable()`, also thought of adding both but after testing found that that is unnecessary

### Why the change?
It was reported in https://github.com/woocommerce/woocommerce-ios/issues/7526 that `.isLoaded()` method which uses this `waitForScreen` from ScreenObject could result in a false positive if the element still exists behind a modal. By updating this to `isHittable` it will no longer work if the element is behind a modal. 

### Testing
Test repos that are using this and make sure that all UI Tests still work - [WCiOS](https://github.com/woocommerce/woocommerce-ios/pull/7654) and [WPiOS](https://github.com/wordpress-mobile/WordPress-iOS/pull/19282). 