### PR TITLE
Add retry to waitforscreen

### DIFF
--- a/Sources/ScreenObject/ScreenObject.swift
+++ b/Sources/ScreenObject/ScreenObject.swift
@@ -124,7 +124,7 @@ open class ScreenObject {
             }
         }
 
-        XCTWaiter().wait(for: [retryExpectation], timeout: defaultWaitTimeout)
+        XCTWaiter().wait(for: [retryExpectation], timeout: TimeInterval)
         return self
     }
 

--- a/Sources/ScreenObject/ScreenObject.swift
+++ b/Sources/ScreenObject/ScreenObject.swift
@@ -9,6 +9,9 @@ open class ScreenObject {
     /// The default time used when waiting.
     public static let defaultWaitTimeout: TimeInterval = 20
 
+    /// Waiting time before retry
+    public static let retryWaitTime: UInt32 = 1
+
     public enum WaitForScreenError: Equatable, Error {
         case timedOut
     }
@@ -109,13 +112,13 @@ open class ScreenObject {
                     }
                 }
                 break
-            } catch {
+            } catch let error {
                 if currentRetryCount < maxRetries {
-                    // Wait 1 second before retrying
-                    sleep(1)
+                    // Wait before attempting to retry again
+                    sleep(Self.retryWaitTime)
                     continue
                 } else {
-                    throw WaitForScreenError.timedOut
+                    throw error
                 }
             }
         }

--- a/Sources/ScreenObject/ScreenObject.swift
+++ b/Sources/ScreenObject/ScreenObject.swift
@@ -96,7 +96,6 @@ open class ScreenObject {
         var currentRetryCount = 0
         while currentRetryCount < maxRetries {
             currentRetryCount += 1
-
             do {
                 try XCTContext.runActivity(named: activityDescription) { (activity) in
                     try gettersToTest.forEach { getter in
@@ -111,7 +110,6 @@ open class ScreenObject {
                 }
                 break
             } catch {
-                print("element not hittable, try again")
                 if currentRetryCount < maxRetries {
                     // Wait 1 second before retrying
                     sleep(1)
@@ -121,7 +119,6 @@ open class ScreenObject {
                 }
             }
         }
-
         return self
     }
 

--- a/Sources/ScreenObject/ScreenObject.swift
+++ b/Sources/ScreenObject/ScreenObject.swift
@@ -93,9 +93,7 @@ open class ScreenObject {
             activityDescription = "Confirm whole screen \(self) is loaded"
         }
 
-        let retryExpectation = XCTestExpectation(description: "Retry expectation")
         var currentRetryCount = 0
-
         while currentRetryCount < maxRetries {
             currentRetryCount += 1
 
@@ -113,8 +111,8 @@ open class ScreenObject {
                 }
                 break
             } catch {
+                print("element not hittable, try again")
                 if currentRetryCount < maxRetries {
-                    retryExpectation.fulfill()
                     // Wait 1 second before retrying
                     sleep(1)
                     continue
@@ -124,7 +122,6 @@ open class ScreenObject {
             }
         }
 
-        XCTWaiter().wait(for: [retryExpectation], timeout: Self.defaultWaitTimeout)
         return self
     }
 

--- a/Sources/ScreenObject/ScreenObject.swift
+++ b/Sources/ScreenObject/ScreenObject.swift
@@ -124,7 +124,7 @@ open class ScreenObject {
             }
         }
 
-        XCTWaiter().wait(for: [retryExpectation], timeout: TimeInterval)
+        XCTWaiter().wait(for: [retryExpectation], timeout: Self.defaultWaitTimeout)
         return self
     }
 


### PR DESCRIPTION
### Description
Some tests that have 100% reliability on iPhone are flaky on iPad. The top two are:
1. [testWPcomLoginLogout](https://buildkite.com/organizations/automattic/analytics/suites/jetpack-ios-ui-tests-ipad/tests/0186e8a8-f65e-7a50-9892-e6897c161402?branch=trunk#flaky)
2. [testCreateScheduledPost](https://buildkite.com/organizations/automattic/analytics/suites/jetpack-ios-ui-tests-ipad/tests/01893fb1-beac-7254-8b62-ccc025041fb6?branch=trunk#flaky)

Found that on iPad, certain flows open up a modal on top of a screen instead of redirecting to a new screen. When this happens, _sometimes_, the test hangs when trying to find the right element on the screen. I suspect that when the test reaches the part of the code to verify for elements, the modal has not rendered correctly, so the test cannot find what it's looking for. This PR adds a retry to `waitForScreen` so if, at that point, the screen has not been rendered, it can try again (max 3 retries). 

_Note after testing: For [testCreateScheduledPost](https://buildkite.com/organizations/automattic/analytics/suites/jetpack-ios-ui-tests-ipad/tests/01893fb1-beac-7254-8b62-ccc025041fb6?branch=trunk#flaky), found that the reason that this is happening is that the notice disappears before the test has the chance to tap it, this issue will be tackled separately and not fixed by the changes in this PR_

_One more note: A surprising but pleasant bonus, I discovered that the issue where the first test `testInsightsStatsLoadProperly` would fail consistently on the first run on the simulator, is resolved in this PR. Please see all the test runs after https://github.com/wordpress-mobile/WordPress-iOS/pull/21213/commits/dc9586ccb074ff04f39c3a57d2997e32f0e84590 commit in the [testing PR](https://github.com/wordpress-mobile/WordPress-iOS/pull/21213)_

### Testing
Using https://github.com/wordpress-mobile/WordPress-iOS/pull/21213 to test the changes, tests ran multiple times and checked that this failure does not happen on iPad for `testWPcomLoginLogout` test:
```
Failed to determine hittability of "appSettings" Cell: Activation point invalid and no suggested hit points based on element frame
```