### PR TITLE
Increase default timeout value from 20s to 45s

### DIFF
--- a/.buildkite/commands/run-tests.sh
+++ b/.buildkite/commands/run-tests.sh
@@ -18,4 +18,4 @@ SIMULATOR_NAME=$1
 xcodebuild clean test \
   -project 'ScreenObject.xcodeproj' \
   -scheme 'ScreenObject' \
-  -destination "platform=iOS Simulator,name=$SIMULATOR_NAME,OS=14.5"
+  -destination "platform=iOS Simulator,name=$SIMULATOR_NAME,OS=18.1"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -4,8 +4,8 @@ agents:
   queue: 'mac'
 
 steps:
-  - label: "🧪 Build and Test (iPhone 12 Simulator)"
-    command: .buildkite/commands/run-tests.sh 'iPhone 12'
+  - label: "🧪 Build and Test (iPhone 16 Simulator)"
+    command: .buildkite/commands/run-tests.sh 'iPhone 16'
 
-  - label: "🧪 Build and Test (iPad Pro (12.9-inch) (5th generation) Simulator)"
-    command: .buildkite/commands/run-tests.sh 'iPad Pro (12.9-inch) (5th generation)'
+  - label: "🧪 Build and Test (iPad Pro 13-inch (M4) Simulator)"
+    command: .buildkite/commands/run-tests.sh 'iPad Pro 13-inch (M4)'

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,5 +1,5 @@
 env:
-  IMAGE_ID: xcode-12.5.1
+  IMAGE_ID: xcode-16.1
 agents:
   queue: 'mac'
 

--- a/Sources/ScreenObject/ScreenObject.swift
+++ b/Sources/ScreenObject/ScreenObject.swift
@@ -7,7 +7,7 @@ import XCTest
 open class ScreenObject {
 
     /// The default time used when waiting.
-    public static let defaultWaitTimeout: TimeInterval = 30
+    public static let defaultWaitTimeout: TimeInterval = 45
 
     /// Waiting time before retry
     public static let retryWaitTime: UInt32 = 1

--- a/Sources/ScreenObject/ScreenObject.swift
+++ b/Sources/ScreenObject/ScreenObject.swift
@@ -7,7 +7,7 @@ import XCTest
 open class ScreenObject {
 
     /// The default time used when waiting.
-    public static let defaultWaitTimeout: TimeInterval = 20
+    public static let defaultWaitTimeout: TimeInterval = 30
 
     /// Waiting time before retry
     public static let retryWaitTime: UInt32 = 1


### PR DESCRIPTION
### Description
There's been slowness when running tests in CI after recent CI updates. Looking at the most recent three testing builds for WCiOS, all three failed at different screens due to timeouts/element not ready/not hittable (See: [1](https://buildkite.com/organizations/automattic/analytics/suites/woocommerce-ios-ui-tests-iphone/runs/16fbdf91-106f-8b95-ac7d-1ed9312b0765), [2](https://buildkite.com/organizations/automattic/analytics/suites/woocommerce-ios-ui-tests-iphone/runs/294791c0-b2b0-80aa-ac1d-27c2d44ea0cb), [3](https://buildkite.com/organizations/automattic/analytics/suites/woocommerce-ios-ui-tests-iphone/runs/3a399223-5fa6-88aa-80b9-b8273c74b5fe))

This PR is a small change to update the default timeout value from 20 to 45 seconds. I decided on 45 seconds because some of the screens used in WCiOS use a custom timeout of 35 but still fail with timeout errors. 